### PR TITLE
Fix PHP warning due to non-numeric value in line 196

### DIFF
--- a/shortcode-star-rating.php
+++ b/shortcode-star-rating.php
@@ -164,6 +164,7 @@ class ShortcodeStarRating {
 
 		/* Display tyle: rating */
 		if( $type == "rating" ) {
+			$rating = 0;
 			// 小数点以下の最後が0の場合は削除
 			if( is_float( $rating ) ) {
 				$rating = preg_replace( '/\.?0+$/', '', (int)$rating );


### PR DESCRIPTION
This pull requests fixes PHP warning 'A non-numeric value encountered' by initializing the $rating variable properly.